### PR TITLE
Add render exception config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,7 @@ group :development do
   # gem 'guard-minitest'
   # gem 'minitest-reporters'
 end
+
+group :test do
+  gem 'mocha', '1.4.0'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,9 +56,12 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.0)
       mini_mime (>= 0.1.1)
+    metaclass (0.0.4)
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
+    mocha (1.4.0)
+      metaclass (~> 0.0.1)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     rack (1.6.9)
@@ -106,7 +109,8 @@ PLATFORMS
 
 DEPENDENCIES
   mjml-rails!
+  mocha (= 1.4.0)
   rails (= 4.2.6)
 
 BUNDLED WITH
-   1.14.6
+   1.16.1

--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -5,9 +5,10 @@ require "mjml/railtie"
 require "rubygems"
 
 module Mjml
-  mattr_accessor :template_language
+  mattr_accessor :template_language, :raise_render_exception
 
   @@template_language = :erb
+  @@raise_render_exception = false
 
   def self.check_version(bin)
     IO.popen("#{bin} --version").read.include?('mjml-core: 4.0.')

--- a/lib/mjml/parser.rb
+++ b/lib/mjml/parser.rb
@@ -19,7 +19,7 @@ module Mjml
       remove_tmp_files
       result
     rescue
-
+      raise if Mjml.raise_render_exception
       ""
     end
 

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+describe Mjml::Parser do
+  let(:input) { mock('input') }
+  let(:parser) { Mjml::Parser.new(input) }
+
+  describe '#render' do
+    describe 'when execption is raised' do
+      let(:custom_error_class) { Class.new(StandardError) }
+      let(:error) { custom_error_class.new('custom error') }
+
+      before do
+        parser.stubs(:run).raises(error)
+      end
+
+      describe 'when render exception raising is enabled' do
+        before do
+          Mjml.setup do |config|
+            config.raise_render_exception = true
+          end
+        end
+
+        it 'raises exception' do
+          -> { parser.render }.must_raise(custom_error_class, error.message)
+        end
+      end
+
+      describe 'when render exception raising is disabled' do
+        before do
+          Mjml.setup do |config|
+            config.raise_render_exception = false
+          end
+        end
+
+        it 'returns empty string' do
+          parser.render.must_equal ''
+        end
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,7 @@ require "action_mailer"
 require "rails/railtie"
 require "rails/generators"
 require "rails/generators/test_case"
+require 'mocha/minitest'
 
 # require "minitest/reporters"
 # Minitest::Reporters.use!


### PR DESCRIPTION
## Why is this necessary?
* Current implementation of swallowing error in `Mjml::Parse#render` method is dangerous. Particularly, it does not only produce confusing result, but also make it difficult to debug.

## What were changed?
* Add exception raising configuration for Mjml::Parse#render method:
```ruby
Mjml.setup do |config|
  # Default is `false` (errors suppressed), set to `true` to enable error raising
  config.raise_render_exception = true
end
```