### PR TITLE
Replace backtick with Open3 for parser

### DIFF
--- a/lib/mjml/parser.rb
+++ b/lib/mjml/parser.rb
@@ -1,5 +1,8 @@
+require 'open3'
+
 module Mjml
   class Parser
+    class ParseError < StandardError; end
 
     # Create new parser
     #
@@ -28,8 +31,9 @@ module Mjml
     # @return [String] The result as string
     def run
       command = "#{mjml_bin} -r #{in_tmp_file} -o #{out_tmp_file}"
-      # puts command
-      `#{command}`
+      _, _, stderr, _ = Open3.popen3(command)
+      raise ParseError.new(stderr.read.chomp) unless stderr.eof?
+
       file = File.open(out_tmp_file, 'r')
       str  = file.read
       file.close

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -38,4 +38,17 @@ describe Mjml::Parser do
       end
     end
   end
+
+  describe '#run' do
+    describe 'when shell command is failed' do
+      let(:error) { 'shell error' }
+      let(:stderr) { mock('stderr', eof?: false, read: error) }
+
+      before { Open3.stubs(popen3: [nil, nil, stderr, nil]) }
+
+      it 'raises exception' do
+        -> { parser.run }.must_raise(Mjml::Parser::ParseError, error)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Why is this necessary?
* `Mjml::Parse#run` swallows shell execution error by using backtick syntax. Causing failure for subsequence instructions.

## What were changed?
* Use `Open3.popen3` to support error raising for `Mjml::Parse#run` method.